### PR TITLE
Support multiple registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ Use this GitHub Action to [log in to a private container registry](https://docs.
 ```
 Refer to the action metadata file for details about all the inputs: [action.yml](https://github.com/Azure/docker-login/blob/master/action.yml)
 
+## Logging in to multiple registries
+To log in to multiple registries, simply run this action several times with different credentials; they will accumulate.
+
+```yaml
+- uses: azure/docker-login@v1
+  with:
+    login-server: contoso.azurecr.io
+    username: ${{ secrets.ACR_USERNAME }}
+    password: ${{ secrets.ACR_PASSWORD }}
+- uses: azure/docker-login@v1
+  with:
+    login-server: index.docker.io
+    username: ${{ secrets.DOCKERIO_USERNAME }}
+    password: ${{ secrets.DOCKERIO_PASSWORD }}
+- run: |
+    docker pull contoso.azurecr.io/private/image:latest
+    docker pull private/image:latest
+```
+
 ## You can build and push container registry by using the following example
 ```yaml
 - uses: azure/docker-login@v1

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,10 +1,9 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -20,17 +19,33 @@ function run() {
         let password = core.getInput('password', { required: true });
         let loginServer = core.getInput('login-server', { required: true });
         let authenticationToken = Buffer.from(`${username}:${password}`).toString('base64');
-        let config = {
-            "auths": {
-                [loginServer]: {
-                    auth: authenticationToken
-                }
-            }
-        };
+        let config;
         const runnerTempDirectory = process.env['RUNNER_TEMP']; // Using process.env until the core libs are updated
-        const dirPath = path.join(runnerTempDirectory, `docker_login_${Date.now()}`);
+        const dirPath = process.env['DOCKER_CONFIG'] || path.join(runnerTempDirectory, `docker_login_${Date.now()}`);
         yield io.mkdirP(dirPath);
         const dockerConfigPath = path.join(dirPath, `config.json`);
+        if (fs.existsSync(dockerConfigPath)) {
+            try {
+                config = JSON.parse(fs.readFileSync(dockerConfigPath, 'utf8'));
+                if (!config.auths) {
+                    config.auths = {};
+                }
+                config.auths[loginServer] = { auth: authenticationToken };
+            }
+            catch (err) {
+                // if the file is invalid, just overwrite it
+                config = undefined;
+            }
+        }
+        if (!config) {
+            config = {
+                "auths": {
+                    [loginServer]: {
+                        auth: authenticationToken
+                    }
+                }
+            };
+        }
         core.debug(`Writing docker config contents to ${dockerConfigPath}`);
         fs.writeFileSync(dockerConfigPath, JSON.stringify(config));
         command_1.issueCommand('set-env', { name: 'DOCKER_CONFIG' }, dirPath);

--- a/src/login.ts
+++ b/src/login.ts
@@ -4,24 +4,43 @@ import { issueCommand } from '@actions/core/lib/command';
 import * as path from 'path';
 import * as fs from 'fs';
 
+interface dockerConfig {
+    auths?: {[key: string]: {auth: string}}
+}
+
 async function run() {
     let username = core.getInput('username', { required: true });
     let password = core.getInput('password', { required: true });
     let loginServer = core.getInput('login-server', { required: true });
     let authenticationToken = Buffer.from(`${username}:${password}`).toString('base64');
 
-    let config = {
-        "auths": {
-            [loginServer]: {
-                auth: authenticationToken
+    let config: dockerConfig;
+
+    const runnerTempDirectory = process.env['RUNNER_TEMP']; // Using process.env until the core libs are updated
+    const dirPath = process.env['DOCKER_CONFIG'] || path.join(runnerTempDirectory, `docker_login_${Date.now()}`);
+    await io.mkdirP(dirPath);
+    const dockerConfigPath = path.join(dirPath, `config.json`);
+    if (fs.existsSync(dockerConfigPath)) {
+        try {
+            config = JSON.parse(fs.readFileSync(dockerConfigPath, 'utf8'));
+            if (!config.auths) {
+                config.auths = {};
+            }
+            config.auths[loginServer] = { auth: authenticationToken };
+        } catch (err) {
+            // if the file is invalid, just overwrite it
+            config = undefined;
+        }
+    }
+    if (!config) {
+        config = {
+            "auths": {
+                [loginServer]: {
+                    auth: authenticationToken
+                }
             }
         }
     }
-
-    const runnerTempDirectory = process.env['RUNNER_TEMP']; // Using process.env until the core libs are updated
-    const dirPath = path.join(runnerTempDirectory, `docker_login_${Date.now()}`);
-    await io.mkdirP(dirPath);
-    const dockerConfigPath = path.join(dirPath, `config.json`);
     core.debug(`Writing docker config contents to ${dockerConfigPath}`);
     fs.writeFileSync(dockerConfigPath, JSON.stringify(config));
     issueCommand('set-env', { name: 'DOCKER_CONFIG' }, dirPath);


### PR DESCRIPTION
It's unclear to me on which branch you want pull requests. Let me know if I should be targeting master.

---

This PR adds support for multiple registries. It does so by reading in the `config.json` pointed to by `DOCKER_CONFIG`, if it exists. If it does, it `JSON.parse`s it and adds a new entry to `auths`. If it doesn't, or if there's any problem with reading in and setting the new key, it simply generates a new `config.json` and overwrites the old one.

This differs from the current behavior, which writes a new file and simply changes the env var. If you think I should explicitly state this in the README, I'd be happy to add it.