### PR TITLE
Update to nodejs v20

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Node.js & TypeScript",
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:16-bullseye"
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:20-bullseye"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
 branding:
   color: 'green'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/login.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
             },
             "devDependencies": {
                 "@types/jest": "^29.2.3",
-                "@types/node": "^16.18.0",
+                "@types/node": "^20.10.1",
                 "jest": "^29.3.1",
                 "ts-jest": "^29.0.3",
                 "typescript": "4.9.3"
@@ -1092,10 +1092,13 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "16.18.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-            "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
-            "dev": true
+            "version": "20.10.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
+            "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/prettier": {
             "version": "2.7.1",
@@ -3410,6 +3413,12 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
             "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -4437,10 +4446,13 @@
             }
         },
         "@types/node": {
-            "version": "16.18.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-            "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
-            "dev": true
+            "version": "20.10.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
+            "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/prettier": {
             "version": "2.7.1",
@@ -6148,6 +6160,12 @@
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
             "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "update-browserslist-db": {
             "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@actions/tool-cache": "^1.0.0"
     },
     "devDependencies": {
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.10.1",
         "jest": "^29.3.1",
         "@types/jest": "^29.2.3",
         "ts-jest": "^29.0.3",


### PR DESCRIPTION
As Github Actions are deprecating Node v16, update to use v20.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

https://github.com/Azure/docker-login/issues/63