### PR TITLE
Fix readme to reference docker/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > **Warning**
-> This project is not maintained anymore. I'll upgrade minimal things to fix vulnerabilities and upgrade nodeJs version for compatibility. Please prefer [github/docker-login](https://github.com/docker/login-action)
+> This project is not maintained anymore. I'll upgrade minimal things to fix vulnerabilities and upgrade nodeJs version for compatibility. Please prefer [docker/login-action](https://github.com/docker/login-action)
 
 
 # Log in to a container registry


### PR DESCRIPTION
I'm aware the action is deprecated (and I'll file a ticket asking for it to be removed from the marketplace), but in the interim, this PR fixes the README/marketplace listing...